### PR TITLE
Fixed bamboo error when trying to build the project.

### DIFF
--- a/activiti-app/build.gradle
+++ b/activiti-app/build.gradle
@@ -106,8 +106,8 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             applicationVariants.all { variant ->
-                variant.outputs.each { output ->
-                    output.outputFileName = new File(output.outputFile.parent, output.outputFile.name.replace(".apk", "-${variant.versionName}.apk"))
+                variant.outputs.all { output ->
+                    outputFileName = outputFileName.replace(".apk", "-${variant.versionName}.apk")
                 }
             }
         }


### PR DESCRIPTION
The error is: org.gradle.api.GradleException: Absolute path are not supported when setting an output file name