### PR TITLE
[APS] Ids displayed instead of values after saving form with Typeahead fields

### DIFF
--- a/activiti-app/src/main/java/com/activiti/android/ui/form/fields/TypeAhead.java
+++ b/activiti-app/src/main/java/com/activiti/android/ui/form/fields/TypeAhead.java
@@ -229,6 +229,12 @@ public class TypeAhead extends BaseField
                         {
                             optionsValue.add(item.getName());
                             optionsIndex.put(item.getName(), item);
+
+                            if (originalValue instanceof String) {
+                                if (item.getId().equals(originalValue)) {
+                                    editionValue = item;
+                                }
+                            }
                         }
 
                         ArrayAdapter adapter = new TypeAheadAdapter(getFragment().getActivity(),
@@ -236,6 +242,7 @@ public class TypeAhead extends BaseField
                         ((MaterialMultiAutoCompleteTextView) editionView).setAdapter(adapter);
                         ((MaterialMultiAutoCompleteTextView) editionView).setTokenizer(new SpaceTokenizer());
                         ((MaterialMultiAutoCompleteTextView) editionView).setThreshold(1);
+                        getFormManager().refreshViews();
                     }
 
                     @Override


### PR DESCRIPTION
JIRA https://issues.alfresco.com/jira/browse/ANDROID-819